### PR TITLE
[Fix] write introduce page after action

### DIFF
--- a/src/reducers/groupSlice.js
+++ b/src/reducers/groupSlice.js
@@ -63,8 +63,9 @@ const { actions, reducer } = createSlice({
     clearWriteFields(state) {
       return {
         ...state,
-        writeField: writeInitialState,
         groupId: null,
+        originalArticleId: null,
+        writeField: writeInitialState,
       };
     },
 


### PR DESCRIPTION
- The phenomenon that the edit button appears when moving to the writing page after editing the study introduction
- 스터디 모집글 작성 후 수정 페이지로 이동 한 뒤 다시 글 작성 페이지로 이동하면 등록하기 버튼이 아닌 수정하기 버튼으로 계속 나오는 현상 수정
- `originalArticleId`의 내용을 `unmount`되면 clear