### PR TITLE
[improve] Study writing error handling

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -1,0 +1,8 @@
+import devConfig from './dev';
+import prodConfig from './prod';
+
+const config = process.env.NODE_ENV === 'production'
+  ? prodConfig
+  : devConfig;
+
+export default config;

--- a/src/components/write/WriteButtons.jsx
+++ b/src/components/write/WriteButtons.jsx
@@ -1,14 +1,13 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 
 import sanitize from 'sanitize-html';
 
-import palette from '../../styles/palette';
-import { ERROR_MESSAGE } from '../../util/messages';
-
 import Button from '../../styles/Button';
+import palette from '../../styles/palette';
+import { ERROR_MESSAGE, FIREBASE_GROUP_ERROR_MESSAGE } from '../../util/messages';
 
 const WriteButtonsWrapper = styled.div`
   margin-top: 3rem;
@@ -47,7 +46,13 @@ const SubmitButton = styled(Button)`
 `;
 
 const {
-  NO_TAG, FAST_APPLY_DEADLINE, NO_CONTENTS, NO_TITLE, NO_APPLY_DATE, ERROR_PERSONNEL,
+  NO_TAG,
+  FAST_APPLY_DEADLINE,
+  NO_CONTENTS, NO_TITLE,
+  NO_APPLY_DATE,
+  ERROR_PERSONNEL,
+  FAILURE_OPEN_STUDY,
+  FAILURE_EDIT_STUDY,
 } = ERROR_MESSAGE;
 
 const isCheckApplyEndDate = (applyDate) => Date.now() - applyDate >= 0;
@@ -55,7 +60,7 @@ const removeHtml = (body) => sanitize(body, { allowedTags: [] }).trim();
 const isCheckPersonnel = (personnel) => !Number.isInteger(personnel) || personnel < 1;
 
 const WriteButtons = ({
-  fields, onSubmit, onCancel, isEdit,
+  fields, onSubmit, onCancel, isEdit, groupError,
 }) => {
   const [error, setError] = useState(null);
 
@@ -98,6 +103,15 @@ const WriteButtons = ({
 
     onSubmit();
   };
+
+  useEffect(() => {
+    if (groupError) {
+      setError(
+        FIREBASE_GROUP_ERROR_MESSAGE[groupError]
+        || (isEdit ? FAILURE_EDIT_STUDY : FAILURE_OPEN_STUDY),
+      );
+    }
+  }, [groupError]);
 
   return (
     <>

--- a/src/components/write/WriteButtons.test.jsx
+++ b/src/components/write/WriteButtons.test.jsx
@@ -14,12 +14,13 @@ describe('WriteButtons', () => {
     jest.clearAllMocks();
   });
 
-  const renderWriteButtons = ({ fields, originalArticleId = false }) => render((
+  const renderWriteButtons = ({ fields, originalArticleId = false, groupError }) => render((
     <WriteButtons
       fields={fields}
       isEdit={originalArticleId}
       onSubmit={handleSubmit}
       onCancel={handleCancel}
+      groupError={groupError}
     />
   ));
 
@@ -150,6 +151,34 @@ describe('WriteButtons', () => {
         });
       });
 
+      describe('when groupError exists', () => {
+        context('When groupError is permission denied', () => {
+          it('renders error message "permission denied"', () => {
+            const { container, getByText } = renderWriteButtons({
+              fields: WRITE_FROM,
+              groupError: 'permission-denied',
+            });
+
+            fireEvent.click(getByText('등록하기'));
+
+            expect(container).toHaveTextContent('권한이 거부되었습니다.');
+          });
+        });
+
+        context('When groupError is writing an article and another error', () => {
+          it('renders error message "Failed to open the study."', () => {
+            const { container, getByText } = renderWriteButtons({
+              fields: WRITE_FROM,
+              groupError: 'error',
+            });
+
+            fireEvent.click(getByText('등록하기'));
+
+            expect(container).toHaveTextContent('스터디 개설에 실패하였습니다.');
+          });
+        });
+      });
+
       describe('When the application deadline is earlier than the current time', () => {
         const fields = {
           ...WRITE_FROM,
@@ -175,6 +204,20 @@ describe('WriteButtons', () => {
       });
 
       expect(container).toHaveTextContent('수정하기');
+    });
+
+    describe('When groupError is editing an article and another error', () => {
+      it('renders error message "Failed to open the study."', () => {
+        const { container, getByText } = renderWriteButtons({
+          fields: WRITE_FROM,
+          groupError: 'error',
+          originalArticleId: true,
+        });
+
+        fireEvent.click(getByText('수정하기'));
+
+        expect(container).toHaveTextContent('수정에 실패하였습니다.');
+      });
     });
   });
 });

--- a/src/containers/write/WriteButtonsContainer.jsx
+++ b/src/containers/write/WriteButtonsContainer.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useCallback } from 'react';
 
+import { useUnmount } from 'react-use';
 import { useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { getAuth, getGroup } from '../../util/utils';
-import { editStudyGroup, writeStudyGroup } from '../../reducers/groupSlice';
+import { clearWriteFields, editStudyGroup, writeStudyGroup } from '../../reducers/groupSlice';
 
 import WriteButtons from '../../components/write/WriteButtons';
 
@@ -14,6 +15,7 @@ const WriteButtonsContainer = () => {
 
   const user = useSelector(getAuth('user'));
   const groupId = useSelector(getGroup('groupId'));
+  const groupError = useSelector(getGroup('groupError'));
   const writeField = useSelector(getGroup('writeField'));
   const originalArticleId = useSelector(getGroup('originalArticleId'));
 
@@ -42,11 +44,14 @@ const WriteButtonsContainer = () => {
     history.push('/');
   }, [history]);
 
+  useUnmount(() => dispatch(clearWriteFields()));
+
   return (
     <WriteButtons
       fields={writeField}
       onSubmit={onSubmit}
       onCancel={onCancel}
+      groupError={groupError}
       isEdit={!!originalArticleId}
     />
   );

--- a/src/services/__mocks__/api.js
+++ b/src/services/__mocks__/api.js
@@ -1,8 +1,8 @@
-export const getStudyGroups = async () => [];
+export const getStudyGroups = jest.fn();
 
-export const getStudyGroup = async () => {};
+export const getStudyGroup = jest.fn();
 
-export const postStudyGroup = async () => {};
+export const postStudyGroup = jest.fn();
 
 export const postUserRegister = jest.fn();
 

--- a/src/services/firebase.js
+++ b/src/services/firebase.js
@@ -3,12 +3,7 @@ import firebase from 'firebase/app';
 import 'firebase/auth';
 import 'firebase/firestore';
 
-import devConfig from '../../config/dev';
-import prodConfig from '../../config/prod';
-
-const config = process.env.NODE_ENV === 'production'
-  ? prodConfig
-  : devConfig;
+import config from '../../config';
 
 firebase.initializeApp(config);
 

--- a/src/util/messages.js
+++ b/src/util/messages.js
@@ -10,6 +10,8 @@ export const ERROR_MESSAGE = {
   NO_TITLE: '제목을 입력해주세요.',
   NO_APPLY_DATE: '모집 마감 일자를 입력해주세요.',
   ERROR_PERSONNEL: '참여 인원 수를 입력하지 않았거나, 잘못된 값을 입력하였습니다.',
+  FAILURE_OPEN_STUDY: '스터디 개설에 실패하였습니다.',
+  FAILURE_EDIT_STUDY: '수정에 실패하였습니다.',
 };
 
 export const FIREBASE_AUTH_ERROR_MESSAGE = {
@@ -19,4 +21,8 @@ export const FIREBASE_AUTH_ERROR_MESSAGE = {
   'auth/wrong-password': '비밀번호가 일치하지 않습니다.',
   'auth/user-not-found': '가입된 사용자가 아닙니다.',
   'auth/invalid-email': '이메일 형식으로 입력하세요.',
+};
+
+export const FIREBASE_GROUP_ERROR_MESSAGE = {
+  'permission-denied': '권한이 거부되었습니다.',
 };


### PR DESCRIPTION
- 글 작성 폼에 대한 api 에러 처리 추가
- 에러가 존재할 때 에러메시지 보이게하기
    - 권한이 없을 때 "권한이 거부되었습니다."
    - 글 작성일 때의 나머지 에러일 때 "스터디 개설에 실패하였습니다."
    - 글 수정일 때의 나머지 에러일 때 "수정에 실패하였습니다."

![image](https://user-images.githubusercontent.com/60910665/104813050-eef7b480-5849-11eb-86ad-21ec8e616d09.png)
