### PR TITLE
[Feature] 내 정보 페이지의 회원탈퇴를 위한 비밀번호 검증을 구현하라

### DIFF
--- a/src/components/common/FormModalWindow.jsx
+++ b/src/components/common/FormModalWindow.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+
+import mq from '../../styles/responsive';
+
+import Button from '../../styles/Button';
+
+const FormModalWindowWrapper = styled.div`
+  top: 0;
+  left: 0;
+  position: fixed;
+  z-index: 101;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.25);
+
+  ${(props) => props.visible && css`
+    &.animation {
+      animation-name: fade-in;
+      animation-duration: 0.3s;
+      animation-fill-mode: both;
+    }
+  
+    @keyframes fade-in {
+      0% {
+        opacity: 0;
+      }
+      100% {
+          opacity: 1;
+      }
+    }
+  `};
+`;
+
+const ModalBoxWrapper = styled.div`
+  ${mq({
+    width: ['300px', '320px'],
+  })};
+
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem;
+  border-radius: 6px;
+  box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.125);
+  background: ${({ theme }) => theme.subBaseTone[0]};
+
+  h2 {
+    ${mq({ fontSize: ['1.2rem', '1.4rem'] })};
+
+    margin-top: 0;
+    margin-bottom: 2rem;
+  }
+
+  p {
+    font-size: 1rem;
+    font-family: 'Nanum-Gothic', sans-serif;
+    margin-bottom: 2rem;
+  }
+  
+  .buttons {
+    display: flex;
+    justify-content: flex-end;
+  }
+`;
+
+const StyledButton = styled(Button)`
+  padding: 0.4rem 1rem;
+
+  &:last-of-type {
+    margin-left: .7rem;
+  }
+`;
+
+const FormModalWindow = ({
+  visible,
+  title,
+  confirmText = '확인',
+  cancelText = '취소',
+  onConfirm,
+  onCancel,
+  children,
+}) => {
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <FormModalWindowWrapper visible className="animation">
+      <ModalBoxWrapper>
+        <h2>{title}</h2>
+        <form onSubmit={onConfirm}>
+          {children}
+          <div className="buttons">
+            <StyledButton type="button" onClick={onCancel}>{cancelText}</StyledButton>
+            {onConfirm && (
+              <StyledButton success type="submit">{confirmText}</StyledButton>
+            )}
+          </div>
+        </form>
+      </ModalBoxWrapper>
+    </FormModalWindowWrapper>
+  );
+};
+
+export default FormModalWindow;

--- a/src/components/common/FormModalWindow.test.jsx
+++ b/src/components/common/FormModalWindow.test.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import FormModalWindow from './FormModalWindow';
+import MockTheme from './test/MockTheme';
+
+describe('FormModalWindow', () => {
+  const handleConfirm = jest.fn();
+  const handleCancel = jest.fn();
+
+  const renderFormModalWindow = ({ visible, title }) => render((
+    <MockTheme>
+      <FormModalWindow
+        visible={visible}
+        title={title}
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+      >
+        <p>test</p>
+      </FormModalWindow>
+    </MockTheme>
+  ));
+
+  context('with visible', () => {
+    const modal = {
+      visible: true,
+      title: '타이틀',
+    };
+
+    it('renders Modal text', () => {
+      const { container } = renderFormModalWindow(modal);
+
+      expect(container).toHaveTextContent('타이틀');
+      expect(container).toHaveTextContent('test');
+    });
+  });
+
+  context('without visible', () => {
+    const modal = {
+      visible: false,
+      title: '타이틀',
+    };
+
+    it("doesn't renders Modal text", () => {
+      const { container } = renderFormModalWindow(modal);
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/src/components/myInfo/MembershipWithdrawal.jsx
+++ b/src/components/myInfo/MembershipWithdrawal.jsx
@@ -1,0 +1,69 @@
+import React, { useState, useCallback } from 'react';
+
+import styled from '@emotion/styled';
+
+import Button from '../../styles/Button';
+
+import ConfirmPasswordModal from './modal/ConfirmPasswordModal';
+import AskMembershipWithdrawalModal from './modal/AskMembershipWithdrawalModal';
+
+const MembershipWithdrawalWrapper = styled.div`
+
+`;
+
+const MembershipWithdrawal = ({ onMembershipWithdrawal, onVerificationPassword }) => {
+  const [password, setPassword] = useState('');
+  const [askModal, setAskModal] = useState(false);
+  const [verificationPasswordModal, setVerificationPasswordModal] = useState(false);
+
+  const handleClickDeleteUser = () => setVerificationPasswordModal(true);
+
+  const handleMembershipWithdrawalCancel = () => setAskModal(false);
+
+  const handleChange = (e) => setPassword(e.target.value);
+
+  const handleMembershipWithdrawalConfirm = () => {
+    setAskModal(false);
+    onMembershipWithdrawal();
+  };
+
+  const handleVerificationPasswordConfirm = useCallback((e) => {
+    e.preventDefault();
+
+    if (!password.trim()) {
+      return;
+    }
+
+    onVerificationPassword(password);
+    // TODO - 성공 / 실패 분리 로직 추가하기
+    setVerificationPasswordModal(false);
+    setAskModal(true);
+  }, [password]);
+
+  const handleVerificationPasswordCancel = () => setVerificationPasswordModal(false);
+
+  return (
+    <MembershipWithdrawalWrapper>
+      <Button
+        warn
+        onClick={handleClickDeleteUser}
+      >
+        회원 탈퇴
+      </Button>
+      <AskMembershipWithdrawalModal
+        visible={askModal}
+        onCancel={handleMembershipWithdrawalCancel}
+        onConfirm={handleMembershipWithdrawalConfirm}
+      />
+      <ConfirmPasswordModal
+        password={password}
+        handleChange={handleChange}
+        visible={verificationPasswordModal}
+        onCancel={handleVerificationPasswordCancel}
+        onConfirm={handleVerificationPasswordConfirm}
+      />
+    </MembershipWithdrawalWrapper>
+  );
+};
+
+export default MembershipWithdrawal;

--- a/src/components/myInfo/MembershipWithdrawal.test.jsx
+++ b/src/components/myInfo/MembershipWithdrawal.test.jsx
@@ -1,0 +1,137 @@
+import React from 'react';
+
+import { render, fireEvent } from '@testing-library/react';
+
+import MockTheme from '../common/test/MockTheme';
+import MembershipWithdrawal from './MembershipWithdrawal';
+
+describe('MembershipWithdrawal', () => {
+  const handleMembershipWithdrawalClick = jest.fn();
+  const handleVerificationPassword = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderMembershipWithdrawal = () => render((
+    <MockTheme>
+      <MembershipWithdrawal
+        onMembershipWithdrawal={handleMembershipWithdrawalClick}
+        onVerificationPassword={handleVerificationPassword}
+      />
+    </MockTheme>
+  ));
+
+  it('should be render "회원 탈퇴" button', () => {
+    const { container } = renderMembershipWithdrawal();
+
+    expect(container).toHaveTextContent('회원 탈퇴');
+  });
+
+  describe('When click "회원 탈퇴" button', () => {
+    it('should visible confirm password modal', () => {
+      const { getByText, container } = renderMembershipWithdrawal();
+
+      fireEvent.click(getByText('회원 탈퇴'));
+
+      expect(container).toHaveTextContent('비밀번호 확인');
+    });
+
+    context('without input value', () => {
+      it('should be nothing input value', () => {
+        const { getByText, getByLabelText } = renderMembershipWithdrawal();
+
+        fireEvent.click(getByText('회원 탈퇴'));
+
+        const input = getByLabelText('password-confirm-input');
+
+        expect(input.value).toBe('');
+      });
+
+      describe('When Click VerificationPassword Confirm button ', () => {
+        it('nothing happen anywhere so, renders verification password modal', () => {
+          const { getByText, getByLabelText, container } = renderMembershipWithdrawal();
+
+          fireEvent.click(getByText('회원 탈퇴'));
+
+          const input = getByLabelText('password-confirm-input');
+
+          fireEvent.change(input, {
+            target: { value: '' },
+          });
+
+          fireEvent.submit(getByText('확인'));
+
+          expect(container).toHaveTextContent('비밀번호 확인');
+        });
+      });
+    });
+
+    context('with input value', () => {
+      it('should be change password input value', () => {
+        const { getByText, getByLabelText } = renderMembershipWithdrawal();
+
+        fireEvent.click(getByText('회원 탈퇴'));
+
+        const input = getByLabelText('password-confirm-input');
+
+        fireEvent.change(input, {
+          target: { value: 'password' },
+        });
+
+        expect(input.value).toBe('password');
+      });
+
+      describe('When Click VerificationPassword Confirm button ', () => {
+        it('should be render ask membership withdrawal modal and call VerificationPassword', () => {
+          const { getByText, getByLabelText, container } = renderMembershipWithdrawal();
+
+          fireEvent.click(getByText('회원 탈퇴'));
+
+          const input = getByLabelText('password-confirm-input');
+
+          fireEvent.change(input, {
+            target: { value: 'password' },
+          });
+
+          fireEvent.submit(getByText('확인'));
+
+          expect(handleVerificationPassword).toBeCalledWith('password');
+          expect(container).toHaveTextContent('회원을 탈퇴하시겠습니까?');
+        });
+      });
+
+      describe('When Click in membership withdrawal modal Confirm button ', () => {
+        it('should be call membership withdrawal', () => {
+          const { getByText, getByLabelText } = renderMembershipWithdrawal();
+
+          fireEvent.click(getByText('회원 탈퇴'));
+
+          const input = getByLabelText('password-confirm-input');
+
+          fireEvent.change(input, {
+            target: { value: 'password' },
+          });
+
+          fireEvent.submit(getByText('확인'));
+
+          fireEvent.click(getByText('확인'));
+
+          expect(handleMembershipWithdrawalClick).toBeCalledTimes(1);
+        });
+      });
+    });
+
+    describe('Click membership withdrawal modal cancel button', () => {
+      it("shouldn't call membership withdrawal", () => {
+        const { getByText } = renderMembershipWithdrawal();
+
+        fireEvent.click(getByText('회원 탈퇴'));
+
+        fireEvent.click(getByText('취소'));
+
+        expect(handleMembershipWithdrawalClick).not.toBeCalled();
+      });
+    });
+  });
+});

--- a/src/components/myInfo/ProfileSettingForm.jsx
+++ b/src/components/myInfo/ProfileSettingForm.jsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import styled from '@emotion/styled';
 
 import Button from '../../styles/Button';
-import AskMembershipWithdrawal from './modal/AskMembershipWithdrawal';
+import MembershipWithdrawal from './MembershipWithdrawal';
 
 const ProfileDetailFormWrapper = styled.div`
 
@@ -14,57 +14,38 @@ const ProfileDetailForm = ({
   onMembershipWithdrawal,
   onSendEmailVerification,
   onSendPasswordResetEmail,
-}) => {
-  const [modal, setModal] = useState(false);
-
-  const handleClickDeleteUser = () => setModal(true);
-
-  const handleCancel = () => setModal(false);
-
-  const handleConfirm = () => {
-    setModal(false);
-    onMembershipWithdrawal();
-  };
-
-  return (
-    <ProfileDetailFormWrapper>
-      <div>
-        {`이메일: ${user.email}`}
-        {user.emailVerified ? (
-          <div> 이메일 인증 완료 </div>
-        ) : (
-          <Button
-            onClick={onSendEmailVerification}
-          >
-            이메일 인증 하기
-          </Button>
-        )}
-      </div>
-      <div>
-        {`별명: ${user.displayName || user.email}`}
-      </div>
-      <div>
-        {`프로필: ${user.photoURL || '없음'} `}
-      </div>
-      <Button
-        success
-        onClick={onSendPasswordResetEmail}
-      >
-        비밀번호 재설정
-      </Button>
-      <Button
-        warn
-        onClick={handleClickDeleteUser}
-      >
-        회원 탈퇴
-      </Button>
-      <AskMembershipWithdrawal
-        visible={modal}
-        onCancel={handleCancel}
-        onConfirm={handleConfirm}
-      />
-    </ProfileDetailFormWrapper>
-  );
-};
+  onVerificationPassword,
+}) => (
+  <ProfileDetailFormWrapper>
+    <div>
+      {`이메일: ${user.email}`}
+      {user.emailVerified ? (
+        <div> 이메일 인증 완료 </div>
+      ) : (
+        <Button
+          onClick={onSendEmailVerification}
+        >
+          이메일 인증 하기
+        </Button>
+      )}
+    </div>
+    <div>
+      {`별명: ${user.displayName || user.email}`}
+    </div>
+    <div>
+      {`프로필: ${user.photoURL || '없음'} `}
+    </div>
+    <Button
+      success
+      onClick={onSendPasswordResetEmail}
+    >
+      비밀번호 재설정
+    </Button>
+    <MembershipWithdrawal
+      onVerificationPassword={onVerificationPassword}
+      onMembershipWithdrawal={onMembershipWithdrawal}
+    />
+  </ProfileDetailFormWrapper>
+);
 
 export default ProfileDetailForm;

--- a/src/components/myInfo/ProfileSettingForm.test.jsx
+++ b/src/components/myInfo/ProfileSettingForm.test.jsx
@@ -42,47 +42,6 @@ describe('ProfileSettingForm', () => {
     });
   });
 
-  describe('When click "회원 탈퇴" button', () => {
-    given('user', () => ({
-      email: 'test@test.com',
-      emailVerified: false,
-      displayName: null,
-      photoURL: null,
-    }));
-
-    it('should visible ask membership withdrawal', () => {
-      const { getByText, container } = renderProfileSettingForm();
-
-      fireEvent.click(getByText('회원 탈퇴'));
-
-      expect(container).toHaveTextContent('회원을 탈퇴하시겠습니까?');
-    });
-
-    describe('Click membership withdrawal modal confirm button', () => {
-      it('should call membership withdrawal', () => {
-        const { getByText } = renderProfileSettingForm();
-
-        fireEvent.click(getByText('회원 탈퇴'));
-
-        fireEvent.click(getByText('확인'));
-
-        expect(handleMembershipWithdrawal).toBeCalledTimes(1);
-      });
-    });
-
-    describe('Click membership withdrawal modal cancel button', () => {
-      it("shouldn't call membership withdrawal", () => {
-        const { getByText } = renderProfileSettingForm();
-
-        fireEvent.click(getByText('회원 탈퇴'));
-
-        fireEvent.click(getByText('취소'));
-
-        expect(handleMembershipWithdrawal).not.toBeCalled();
-      });
-    });
-  });
-
   context('Is email verify', () => {
     context('with displayName and photoURL', () => {
       given('user', () => ({

--- a/src/components/myInfo/modal/AskMembershipWithdrawalModal.jsx
+++ b/src/components/myInfo/modal/AskMembershipWithdrawalModal.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import ModalWindow from '../../common/ModalWindow';
 
-const AskMembershipWithdrawal = ({ visible, onCancel, onConfirm }) => (
+const AskMembershipWithdrawalModal = ({ visible, onCancel, onConfirm }) => (
   <ModalWindow
     title="회원 탈퇴"
     description="회원을 탈퇴하시겠습니까?"
@@ -12,4 +12,4 @@ const AskMembershipWithdrawal = ({ visible, onCancel, onConfirm }) => (
   />
 );
 
-export default AskMembershipWithdrawal;
+export default AskMembershipWithdrawalModal;

--- a/src/components/myInfo/modal/AskMembershipWithdrawalModal.test.jsx
+++ b/src/components/myInfo/modal/AskMembershipWithdrawalModal.test.jsx
@@ -3,15 +3,15 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
 import MockTheme from '../../common/test/MockTheme';
-import AskMembershipWithdrawal from './AskMembershipWithdrawal';
+import AskMembershipWithdrawalModal from './AskMembershipWithdrawalModal';
 
-describe('AskMembershipWithdrawal', () => {
+describe('AskMembershipWithdrawalModal', () => {
   const handleCancel = jest.fn();
   const handleConfirm = jest.fn();
 
-  const renderAskMembershipWithdrawal = ({ visible }) => render((
+  const renderAskMembershipWithdrawalModal = ({ visible }) => render((
     <MockTheme>
-      <AskMembershipWithdrawal
+      <AskMembershipWithdrawalModal
         visible={visible}
         onConfirm={handleConfirm}
         onCancel={handleCancel}
@@ -25,14 +25,14 @@ describe('AskMembershipWithdrawal', () => {
     };
 
     it('renders Modal text', () => {
-      const { container } = renderAskMembershipWithdrawal(modal);
+      const { container } = renderAskMembershipWithdrawalModal(modal);
 
       expect(container).toHaveTextContent('회원 탈퇴');
       expect(container).toHaveTextContent('회원을 탈퇴하시겠습니까?');
     });
 
     it('calls confirm event action', () => {
-      const { getByText } = renderAskMembershipWithdrawal(modal);
+      const { getByText } = renderAskMembershipWithdrawalModal(modal);
 
       const button = getByText('확인');
 
@@ -42,7 +42,7 @@ describe('AskMembershipWithdrawal', () => {
     });
 
     it('calls cancel event action', () => {
-      const { getByText } = renderAskMembershipWithdrawal(modal);
+      const { getByText } = renderAskMembershipWithdrawalModal(modal);
 
       const button = getByText('취소');
 
@@ -58,7 +58,7 @@ describe('AskMembershipWithdrawal', () => {
     };
 
     it("doesn't renders Modal text", () => {
-      const { container } = renderAskMembershipWithdrawal(modal);
+      const { container } = renderAskMembershipWithdrawalModal(modal);
 
       expect(container).toBeEmptyDOMElement();
     });

--- a/src/components/myInfo/modal/ConfirmPasswordModal.jsx
+++ b/src/components/myInfo/modal/ConfirmPasswordModal.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import FormModalWindow from '../../common/FormModalWindow';
+
+const ConfirmPasswordModal = ({
+  visible, onConfirm, onCancel, handleChange, password,
+}) => (
+  <FormModalWindow
+    title="비밀번호 확인"
+    visible={visible}
+    onConfirm={onConfirm}
+    onCancel={onCancel}
+  >
+    <input
+      type="password"
+      autoComplete="password"
+      value={password}
+      onChange={handleChange}
+      aria-label="password-confirm-input"
+    />
+  </FormModalWindow>
+);
+
+export default ConfirmPasswordModal;

--- a/src/components/myInfo/modal/ConfirmPasswordModal.test.jsx
+++ b/src/components/myInfo/modal/ConfirmPasswordModal.test.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+
+import { render, fireEvent } from '@testing-library/react';
+
+import MockTheme from '../../common/test/MockTheme';
+import ConfirmPasswordModal from './ConfirmPasswordModal';
+
+describe('ConfirmPasswordModal', () => {
+  const handleCancel = jest.fn();
+  const handleConfirm = jest.fn();
+  const handleChange = jest.fn();
+
+  const renderConfirmPasswordModal = ({ visible }) => render((
+    <MockTheme>
+      <ConfirmPasswordModal
+        password=""
+        visible={visible}
+        onCancel={handleCancel}
+        onConfirm={handleConfirm}
+        handleChange={handleChange}
+      />
+    </MockTheme>
+  ));
+
+  context('Is visible', () => {
+    it('should be render password confirm input and title', () => {
+      const { container, getByLabelText } = renderConfirmPasswordModal({
+        visible: true,
+      });
+
+      expect(container).toHaveTextContent('비밀번호 확인');
+      expect(getByLabelText('password-confirm-input')).not.toBeNull();
+    });
+
+    it('should be listen call cancel event', () => {
+      const { getByText } = renderConfirmPasswordModal({
+        visible: true,
+      });
+
+      fireEvent.click(getByText('취소'));
+
+      expect(handleCancel).toBeCalledTimes(1);
+    });
+
+    it('should be listen call confirm event', () => {
+      const { getByText } = renderConfirmPasswordModal({
+        visible: true,
+      });
+
+      fireEvent.submit(getByText('확인'));
+
+      expect(handleConfirm).toBeCalledTimes(1);
+    });
+
+    it('should be listen call input change event', () => {
+      const { getByLabelText } = renderConfirmPasswordModal({
+        visible: true,
+      });
+
+      const input = getByLabelText('password-confirm-input');
+
+      fireEvent.change(input, {
+        target: { value: 'password' },
+      });
+
+      expect(handleChange).toBeCalledTimes(1);
+    });
+  });
+
+  context("Isn't visible", () => {
+    it('should be render password confirm input', () => {
+      const { container } = renderConfirmPasswordModal({
+        visible: false,
+      });
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/src/containers/myInfo/ProfileSettingContainer.jsx
+++ b/src/containers/myInfo/ProfileSettingContainer.jsx
@@ -8,7 +8,11 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { getAuth } from '../../util/utils';
 import {
-  requestEmailVerification, clearAuth, requestResetPassword, requestDeleteUser,
+  clearAuth,
+  requestDeleteUser,
+  requestResetPassword,
+  requestEmailVerification,
+  requestReauthenticateWithCredential,
 } from '../../reducers/authSlice';
 import { FIREBASE_AUTH_ERROR_MESSAGE, ERROR_MESSAGE } from '../../util/constants/messages';
 
@@ -39,6 +43,11 @@ const ProfileSettingContainer = ({ user }) => {
     [dispatch],
   );
 
+  const onClickVerificationPassword = useCallback(
+    (password) => dispatch(requestReauthenticateWithCredential(password)),
+    [dispatch],
+  );
+
   useEffect(() => {
     if (authError) {
       toast.error(
@@ -48,6 +57,7 @@ const ProfileSettingContainer = ({ user }) => {
       return;
     }
 
+    // TODO - 성공시 상수로 메시지를 분리해 auth 로직을 분리해주기
     if (auth) {
       toast.success('이메일을 확인해주세요!');
     }
@@ -68,6 +78,7 @@ const ProfileSettingContainer = ({ user }) => {
         onMembershipWithdrawal={onClickMembershipWithdrawal}
         onSendEmailVerification={onClickSendEmailVerification}
         onSendPasswordResetEmail={onClickSendPasswordResetEmail}
+        onVerificationPassword={onClickVerificationPassword}
       />
     </ProfileSettingContainerWrapper>
   );

--- a/src/containers/myInfo/ProfileSettingContainer.test.jsx
+++ b/src/containers/myInfo/ProfileSettingContainer.test.jsx
@@ -67,23 +67,48 @@ describe('ProfileSettingContainer', () => {
     });
 
     describe('Click membership withdrawal button', () => {
-      it('should visible ask membership withdrawal modal', () => {
+      it('should be visible verification Password modal', () => {
         const { getByText, container } = renderProfileSettingContainer(currentUser);
 
         fireEvent.click(getByText(/회원 탈퇴/i));
 
-        expect(container).toHaveTextContent('회원을 탈퇴하시겠습니까?');
+        expect(container).toHaveTextContent('비밀번호 확인');
+      });
+
+      describe('Click verification Password modal confirm button', () => {
+        it('should listen dispatch action event', () => {
+          const { getByText, getByLabelText } = renderProfileSettingContainer(currentUser);
+
+          fireEvent.click(getByText(/회원 탈퇴/i));
+
+          const input = getByLabelText('password-confirm-input');
+
+          fireEvent.change(input, {
+            target: { value: 'password' },
+          });
+
+          fireEvent.submit(input);
+
+          expect(dispatch).toBeCalledTimes(1);
+        });
       });
 
       describe('Click membership withdrawal modal confirm button', () => {
         it('should listen dispatch action event', () => {
-          const { getByText } = renderProfileSettingContainer(currentUser);
+          const { getByText, getByLabelText } = renderProfileSettingContainer(currentUser);
 
           fireEvent.click(getByText(/회원 탈퇴/i));
 
+          const input = getByLabelText('password-confirm-input');
+
+          fireEvent.change(input, {
+            target: { value: 'password' },
+          });
+
+          fireEvent.submit(input);
           fireEvent.click(getByText(/확인/i));
 
-          expect(dispatch).toBeCalledTimes(1);
+          expect(dispatch).toBeCalledTimes(2);
         });
       });
     });


### PR DESCRIPTION
- 비밀번호 검증 로직이 있어야 회원탈퇴가 이루어진다.
- 미 검증시 아무일도 일어나지 않는다.
   - TODO: 에러처리 및 성공 처리

<img width="788" alt="스크린샷 2021-08-26 오후 11 35 27" src="https://user-images.githubusercontent.com/60910665/130982664-c2805fed-1f56-4803-933c-25971073d4b3.png">

